### PR TITLE
Fix PTP adjtime and compile warnings

### DIFF
--- a/r8125_rss.c
+++ b/r8125_rss.c
@@ -57,21 +57,21 @@ static int rtl8125_get_rss_hash_opts(struct rtl8125_private *tp,
         switch (cmd->flow_type) {
         case TCP_V4_FLOW:
                 cmd->data |= RXH_L4_B_0_1 | RXH_L4_B_2_3;
-        /* fallthrough */
+                fallthrough;
         case UDP_V4_FLOW:
                 if (tp->rss_flags & RTL_8125_RSS_FLAG_HASH_UDP_IPV4)
                         cmd->data |= RXH_L4_B_0_1 | RXH_L4_B_2_3;
-        /* fallthrough */
+                fallthrough;
         case IPV4_FLOW:
                 cmd->data |= RXH_IP_SRC | RXH_IP_DST;
                 break;
         case TCP_V6_FLOW:
                 cmd->data |= RXH_L4_B_0_1 | RXH_L4_B_2_3;
-        /* fallthrough */
+                fallthrough;
         case UDP_V6_FLOW:
                 if (tp->rss_flags & RTL_8125_RSS_FLAG_HASH_UDP_IPV6)
                         cmd->data |= RXH_L4_B_0_1 | RXH_L4_B_2_3;
-        /* fallthrough */
+                fallthrough;
         case IPV6_FLOW:
                 cmd->data |= RXH_IP_SRC | RXH_IP_DST;
                 break;


### PR DESCRIPTION
## Description

Fix the `adjtime()` handling which allows the device to function correctly as a PTP master.  This applies the delta expected instead of absolute time which caused `linuxptp` to not converge because every small time adjustment added more and more error.

Also fix minor RSS case statement fall through warnings.

## Test Validation

Tested on an `amd64` machine (integrated into ASRock motherboard) running Arch Linux with kernel `6.1.55-1-lts`.

```
$ sudo ptp4l -m -l6 -i lan0

ptp4l[4323.081]: selected /dev/ptp1 as PTP clock
ptp4l[4323.081]: port 1: INITIALIZING to LISTENING on INIT_COMPLETE
ptp4l[4323.081]: port 0: INITIALIZING to LISTENING on INIT_COMPLETE
ptp4l[4330.424]: port 1: LISTENING to MASTER on ANNOUNCE_RECEIPT_TIMEOUT_EXPIRES
ptp4l[4330.424]: selected local clock a8a159.fffe.123456 as best master
ptp4l[4330.424]: port 1: assuming the grand master role
```


```
$ sudo phc2sys -s CLOCK_REALTIME -c lan0 -w -m

phc2sys[4350.419]: lan0 sys offset  -1438107 s0 freq  -47325 delay  12253
phc2sys[4351.419]: lan0 sys offset  -1446949 s1 freq  -56166 delay  20538
phc2sys[4352.419]: lan0 sys offset      4592 s2 freq  -51574 delay  20548
phc2sys[4353.419]: lan0 sys offset      8464 s2 freq  -46324 delay  12253
phc2sys[4354.419]: lan0 sys offset      2713 s2 freq  -49536 delay  12263
phc2sys[4355.420]: lan0 sys offset     -3801 s2 freq  -55236 delay  20539
phc2sys[4356.420]: lan0 sys offset      3928 s2 freq  -48647 delay  12254
phc2sys[4357.420]: lan0 sys offset      1125 s2 freq  -50272 delay  13355
phc2sys[4358.421]: lan0 sys offset     -5196 s2 freq  -56255 delay  20559
phc2sys[4359.421]: lan0 sys offset      3633 s2 freq  -48985 delay  12253
phc2sys[4360.421]: lan0 sys offset       677 s2 freq  -50851 delay  12263
phc2sys[4361.421]: lan0 sys offset      -323 s2 freq  -51648 delay  12263
phc2sys[4362.421]: lan0 sys offset      -499 s2 freq  -51921 delay  12243
phc2sys[4363.422]: lan0 sys offset     -4526 s2 freq  -56098 delay  20529
phc2sys[4364.422]: lan0 sys offset      4588 s2 freq  -48342 delay  13244
phc2sys[4365.422]: lan0 sys offset       446 s2 freq  -51107 delay  12293
phc2sys[4366.423]: lan0 sys offset       304 s2 freq  -51115 delay  13445
phc2sys[4367.423]: lan0 sys offset      -996 s2 freq  -52324 delay  12263
phc2sys[4368.424]: lan0 sys offset      -445 s2 freq  -52072 delay  12293
phc2sys[4369.424]: lan0 sys offset     -4332 s2 freq  -56093 delay  20599
phc2sys[4370.424]: lan0 sys offset      4279 s2 freq  -48781 delay  12263
phc2sys[4371.424]: lan0 sys offset      1134 s2 freq  -50642 delay  12343
phc2sys[4372.425]: lan0 sys offset       432 s2 freq  -51004 delay  13345
phc2sys[4373.425]: lan0 sys offset      -927 s2 freq  -52234 delay  12344
phc2sys[4374.426]: lan0 sys offset       -48 s2 freq  -51633 delay  13154
phc2sys[4375.426]: lan0 sys offset      -652 s2 freq  -52251 delay  12293
phc2sys[4376.426]: lan0 sys offset        87 s2 freq  -51708 delay  12284
phc2sys[4377.426]: lan0 sys offset     -4463 s2 freq  -56232 delay  20609
phc2sys[4378.427]: lan0 sys offset       195 s2 freq  -52913 delay  20609
phc2sys[4379.427]: lan0 sys offset      1353 s2 freq  -51696 delay  20549
phc2sys[4380.427]: lan0 sys offset      5376 s2 freq  -47267 delay  12264
```
Observe:
1. Time jump with `phc2xsys` and converge with system `CLOCK_REALTIME`. 
2. Remote PTP slave converges to time as expected.

Module built with following features:
```
ENABLE_PTP_SUPPORT=y
ENABLE_PTP_MASTER_MODE=y
```

Also tested briefly with
```
ENABLE_MULTIPLE_TX_QUEUE=y
ENABLE_RSS_SUPPORT=y
```

Hardware info:
```
09:00.0 Ethernet controller: Realtek Semiconductor Co., Ltd. RTL8125 2.5GbE Controller (rev 05)
    Subsystem: ASRock Incorporation RTL8125 2.5GbE Controller
    Flags: bus master, fast devsel, latency 0, IRQ 37, IOMMU group 0
    I/O ports at e000 [size=256]
    Memory at fc600000 (64-bit, non-prefetchable) [size=64K]
    Memory at fc610000 (64-bit, non-prefetchable) [size=16K]
    Capabilities: [40] Power Management version 3
    Capabilities: [50] MSI: Enable- Count=1/1 Maskable+ 64bit+
    Capabilities: [70] Express Endpoint, MSI 01
    Capabilities: [b0] MSI-X: Enable+ Count=32 Masked-
    Capabilities: [d0] Vital Product Data
    Capabilities: [100] Advanced Error Reporting
    Capabilities: [148] Virtual Channel
    Capabilities: [168] Device Serial Number fe-4c-34-59-a1-a8-00-00
    Capabilities: [178] Transaction Processing Hints
    Capabilities: [204] Latency Tolerance Reporting
    Capabilities: [20c] L1 PM Substates
    Capabilities: [21c] Vendor Specific Information: ID=0002 Rev=4 Len=100 <?>
    Kernel driver in use: r8125
    Kernel modules: r8169, r8125
```


## Notes
* There appears to be a **hardware bug** with the hardware timestamp filtering with `linuxptp 4.0` which changed the PTP version in the packet from v2.0 to v2.1.  I had to downgrade my remote test device to send the old version.  Couldn't find a way to timestamp all packets and don't have access to the Realtek 8125 Programming Guide with descriptions of the hardware filters.
* The recent RX patch (0551562647d4ec4fe903bda566c1a625a4cdfb54) is necessary for getting the `RxDescV3` to work correctly otherwise they clobber memory and trigger an IOMMU if you are so lucky and these DMA descriptors are necessary for PTP timestamps.